### PR TITLE
Add handling of Y key to dig left, for German keyboards

### DIFF
--- a/lodeRunner.key.js
+++ b/lodeRunner.key.js
@@ -241,6 +241,7 @@ function pressKey(code)
 		keyAction = ACT_DOWN;
 		break;
 	case KEYCODE_Z:
+	case KEYCODE_Y:
 	case KEYCODE_U:	
 	case KEYCODE_Q:		
 	case KEYCODE_COMMA: //,


### PR DESCRIPTION
This makes it easy to use Y and X for digging, as on the German keyboard layout Y and Z are switched. Please review @SimonHung and thank you for the great game remake! :)